### PR TITLE
Remove version from galaxy.yaml file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,4 +6,3 @@ name: iosxr
 namespace: cisco
 readme: README.rst
 repository: https://github.com/ansible-network/ansible_collections.cisco.iosxr
-version: 0.0.1


### PR DESCRIPTION
We generate our version number via release jobs, so we can stop
hardcoding this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>